### PR TITLE
#165354535 Remove unnecessary fields in credit account page

### DIFF
--- a/credit_user.html
+++ b/credit_user.html
@@ -55,23 +55,12 @@
         <div class="details-container">
             <div class="credit-form">
                 <form>
-                  <div class="input-credit"> 
-                    <select name="" type="text" class="form-control" >
-                      <option value = "">Select type</option>
-                      <option value = "">Current</option><br />
-                      <option value = "">Savings</option><br />
-                    </select>
-                  </div>
                   <div class="input"> 
                     <input type="text" placeholder="Enter account number">
                   </div>
 
                   <div class="input"> 
                     <input type="text" placeholder="Depositor's name">
-                  </div>
-
-                  <div class="input"> 
-                    <input type="text" placeholder="Depositors address">
                   </div>
 
                   <div class="input"> 

--- a/css/credit_user.css
+++ b/css/credit_user.css
@@ -38,6 +38,14 @@ select[type="text"] {
 .credit-form{
   text-align: center;
 }
+
+.fa-plus {
+  color: rgb(118, 185, 9);
+}
+
+.fa-minus {
+  color: rgb(187, 13, 13);
+}
 .nextPrevious td a:hover{
   font-size: 12px;
   transition: 0.5s;

--- a/css/credit_user.css
+++ b/css/credit_user.css
@@ -70,3 +70,11 @@ a:hover {
     width:30%;
   }
 }
+
+@media screen and (max-width: 600px) {
+  .credit-form {
+    padding-top: 100px;
+
+  }
+
+}

--- a/css/debit_user.css
+++ b/css/debit_user.css
@@ -53,6 +53,7 @@ a:hover {
     form{
       flex-wrap: wrap;
     }
+   
     input[type="text"],input[type="password"],input[type="email"],select[type="text"] {
       width:70%;
       margin-top: 15px;
@@ -62,4 +63,4 @@ a:hover {
       width:30%;
     }
   }
-  
+

--- a/css/debit_user.css
+++ b/css/debit_user.css
@@ -21,6 +21,14 @@ input[type="text"]:hover,input[type="password"]:hover,input[type="email"]:hover 
   transition:0.5;
 }
 
+.fa-plus {
+  color: rgb(118, 185, 9);
+}
+
+.fa-minus {
+  color: rgb(187, 13, 13);
+}
+
 .btn {
   background: #035AB7;
   width:10%;

--- a/css/staff_dashboard.css
+++ b/css/staff_dashboard.css
@@ -45,14 +45,17 @@ th, td {
 .fa{
 padding: 10px;
 }
+.fa-plus {
+  color: rgb(118, 185, 9);
+}
+
+.fa-minus {
+  color: rgb(187, 13, 13);
+}
+
 .fa-trash-o {
-  color: rgb(185, 57, 57);
+  color: rgb(187, 18, 18);
 }
-
-.fa-pencil-square-o {
-  color: rgb(73, 73, 47);
-}
-
 .fa-eye {
   color: rgb(3, 26, 54);
 }

--- a/css/user_dashboard.css
+++ b/css/user_dashboard.css
@@ -39,7 +39,7 @@ input[type="text"],input[type="password"],input[type="email"],select[type="text"
   padding:5px;
   border: 1px solid #ddd;
   border-radius: 5px;
-  color:rgb(245, 237, 237);
+  color:rgb(141, 136, 136);
   font-size:1em;
   height:37px;
   outline:none;
@@ -63,26 +63,6 @@ input[type="text"]:hover,input[type="password"]:hover,input[type="email"]:hover 
   border: 1px solid #4484CE;
   cursor:text;
   transition:0.5;
-}
-
-input[type="file"] {
-  display: none;
-  color:rgb(245, 237, 237);
-  font-size:1em;
-  outline:none;
-}
-
-.custom-file-upload {
-  border: 1px solid #ccc;
-  display: inline-block;
-  padding: 8px 12px;
-  cursor: pointer;
-  margin-top: 20px;
-  border-radius: 5px;
-  height:37px;
-  color:rgb(134, 132, 132);
-  font-size:1em;
-
 }
 
 .btn {

--- a/debit_user.html
+++ b/debit_user.html
@@ -57,13 +57,6 @@
             <div class="credit-form">
                 <form>
                   <div class="input"> 
-                    <select name="" type="text" class="form-control" >
-                      <option value = "">Select type</option>
-                      <option value = "">Current</option><br />
-                      <option value = "">Savings</option><br />
-                    </select>
-                  </div>
-                  <div class="input"> 
                       <input type="text" placeholder="Enter account number">
                   </div>
                   <div class="input"> 

--- a/staff_edit_user.html
+++ b/staff_edit_user.html
@@ -74,8 +74,8 @@
                       <td data-label="Tran Amount">03 Jan. 2019</td>
                       <td class="staff-action">
                           <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                          <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                          <a href="#" ><i class="fa fa-trash-o"></i></a>
+                          <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                          <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                       </td>                  
                     </tr>
                     <tr>
@@ -84,9 +84,9 @@
                         <td data-label="Tran type">Savings</td>
                         <td data-label="Tran Amount">03 Jan. 2019</td>
                         <td class="staff-action">
-                            <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                            <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                            <a href="#" ><i class="fa fa-trash-o"></i></a>
+                          <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
+                          <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                          <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                         </td>                  
                     </tr>
                     <tr>
@@ -96,8 +96,8 @@
                         <td data-label="Tran Amount">03 Jan. 2019</td>
                         <td class="staff-action">
                             <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                            <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                            <a href="#" ><i class="fa fa-trash-o"></i></a>
+                            <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                            <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                         </td>                  
                     </tr>
                     <tr>
@@ -107,8 +107,8 @@
                         <td data-label="Tran Amount">03 Jan. 2019</td>
                         <td class="staff-action">
                             <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                            <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                            <a href="#" ><i class="fa fa-trash-o"></i></a>
+                            <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                            <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                         </td>                  
                     </tr>
                     <tr>
@@ -118,8 +118,8 @@
                         <td data-label="Tran Amount">03 Jan. 2019</td>
                         <td class="staff-action">
                             <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                            <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                            <a href="#" ><i class="fa fa-trash-o"></i></a>
+                            <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                            <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                         </td>                  
                     </tr>
                     <tr>
@@ -129,8 +129,8 @@
                         <td data-label="Tran Amount">03 Jan. 2019</td>
                         <td data-label="Amount" class="staff-action">
                             <a href="specific_record.html" ><i class="fa fa-eye"></i></a>
-                            <a href="#" ><i class="fa fa-pencil-square-o"></i></a>
-                            <a href="#" ><i class="fa fa-trash-o"></i></a>
+                            <a href="credit_user.html" ><i class="fa fa-plus"></i></a>
+                            <a href="debit_user.html" ><i class="fa fa-minus"></i></a>
                         </td>                  
                     </tr>
                     <tr class="nextPrevious">

--- a/user_create-account.html
+++ b/user_create-account.html
@@ -65,13 +65,9 @@
                 <option value = "">Savings</option><br />
               </select>
               <input type="text" placeholder="address">
-              <input type="text" placeholder="Next of kin">
               <input type="text" placeholder="Next of kin mobile number">
             </div>
-            <label class="custom-file-upload">
-              <input type="file"/>
-              Upload Passport
-            </label>              <p class="sign-up"> 
+              <p class="sign-up"> 
                 <input type="button" value="Create" class="btn">
               </p>
           </form>


### PR DESCRIPTION
#### What does this PR do?
- It ensures that only necessary text fields are present in the credit, debit, and create account pages.

- It ensures that is only the admin can delete or edit user account.

#### Description of Task to be completed?
- A simple credit and debit page.
- Delete and edit role specifically for admin.

#### How should this be manually tested?
When a staff clicks at the debit or credit navigation link on the sidebar, it will redirect him/her to the page with the text field to input the account number, amount, 

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#165354535

#### Screenshots or gifs (if appropriate)
![staffrole](https://user-images.githubusercontent.com/23107014/56157162-bc56c300-5fb6-11e9-9de0-062e34731f0f.JPG)

#### Questions: