### PR TITLE
#165365486 Check that account number is not empty

### DIFF
--- a/server/middlewares/validateAccountNumber.js
+++ b/server/middlewares/validateAccountNumber.js
@@ -19,6 +19,12 @@ const validateAccountNumber = (req, res, next) => {
       error: 'Account Number must be a 10 digits ',
     });
   }
+  if (accountNumber.toString().replace(/\s/g, '').length === 0) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Account Number must be empty ',
+    });
+  }
   next();
 };
 

--- a/server/middlewares/validateAccountNumber.js
+++ b/server/middlewares/validateAccountNumber.js
@@ -2,6 +2,12 @@
 /* eslint-disable consistent-return */
 const validateAccountNumber = (req, res, next) => {
   const { accountNumber } = req.params;
+  if (accountNumber.toString().replace(/\s/g, '').length === 0) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Account Number must not be empty ',
+    });
+  }
   if (isNaN(accountNumber)) {
     return res.status(400).json({
       status: 400,
@@ -17,12 +23,6 @@ const validateAccountNumber = (req, res, next) => {
     return res.status(400).json({
       status: 400,
       error: 'Account Number must be a 10 digits ',
-    });
-  }
-  if (accountNumber.toString().replace(/\s/g, '').length === 0) {
-    return res.status(400).json({
-      status: 400,
-      error: 'Account Number must be empty ',
     });
   }
   next();


### PR DESCRIPTION
#### What does this PR do?

- It ensures that the account number field was not left empty

#### Description of Task to be completed?
When a user leave the account number field empty or provide a space bar, there should be a validation
instructing the user not to leave the field blank.
 
#### How should this be manually tested?
Add the route below in postman
https://julius-banka.herokuapp.com/api/v1/transactions/    /debit
and provide the json object below
{
    "amount": 45.87,
    "transactionType": "debit"
}

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#165365486

#### Screenshots or gifs (if appropriate)
![checkaccount](https://user-images.githubusercontent.com/23107014/56167352-e072ce00-5fcf-11e9-97de-2a562a960a0b.JPG)

#### Questions: